### PR TITLE
Standardize naming to 'Speedrun Ethereum'

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Welcome to your BuidlGuidl Batch!
 
-🧨 Congratulations on joining a BuidlGuidl Batch! You've completed SpeedRunEthereum and gotten your feet wet in Scaffold-ETH, Solidity coding, deploying contracts, and basic front-end development.  Now it's time to take the next step on your educational journey!  
+🧨 Congratulations on joining a BuidlGuidl Batch! You've completed Speedrun Ethereum and gotten your feet wet in Scaffold-ETH, Solidity coding, deploying contracts, and basic front-end development.  Now it's time to take the next step on your educational journey!  
 
 🧙‍♂️ Along with your fellow batch members and BuidlGuidl mentors you'll learn how to collaborate, meaningfully contribute to GitHub repositories, create and handle issues and pull requests, follow best practices in version control, and dive deeper into full-scale dApp development.
 


### PR DESCRIPTION
Replace inconsistent variations (SpeedRunEthereum, SpeedRun Ethereum, Speed Run Ethereum) with the standardized form 'Speedrun Ethereum'.

Preserved:
- speedrunethereum.com domain
- Repository URLs
- Lowercase references in links

## Description

_Concise description of proposed changes, We recommend using screenshots and videos for better description_

## Additional Information

- [ ] I have read the [contributing docs](/scaffold-eth/scaffold-eth-2/blob/main/CONTRIBUTING.md) (if this is your first contribution)
- [ ] This is not a duplicate of any [existing pull request](https://github.com/scaffold-eth/scaffold-eth-2/pulls)

## Related Issues

_Closes #{issue number}_

_Note: If your changes are small and straightforward, you may skip the creation of an issue beforehand and remove this section. However, for medium-to-large changes, it is recommended to have an open issue for discussion and approval prior to submitting a pull request._

Your ENS/address:
